### PR TITLE
Scope launchctl setenv to the console user so SIP stops blocking it.

### DIFF
--- a/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
@@ -5,8 +5,8 @@
   changed_when: "'Already up-to-date' not in brew_upgrade.stdout and 'Warning:' not in brew_upgrade.stderr"
   failed_when: brew_upgrade.rc != 0 and 'already installed' not in brew_upgrade.stderr | lower
 
-- name: Set Ollama environment variables (LaunchAgent plist)
-  include_tasks: utilities/system_env.yml
+- name: Set Ollama environment variables (user Aqua session)
+  include_tasks: utilities/user_aqua_env.yml
   when: ollama_expose
   loop:
     - { name: OLLAMA_HOST, value: "{{ ollama_host }}" }

--- a/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
@@ -1,6 +1,6 @@
 ---
 - name: Upgrade Ollama via Homebrew Cask
-  ansible.builtin.command: brew upgrade --cask ollama-app
+  ansible.builtin.command: "{{ homebrew_path }}/bin/brew upgrade --cask ollama-app"
   register: brew_upgrade
   changed_when: "'Already up-to-date' not in brew_upgrade.stdout and 'Warning:' not in brew_upgrade.stderr"
   failed_when: brew_upgrade.rc != 0 and 'already installed' not in brew_upgrade.stderr | lower

--- a/bootstrap/roles/bootstrap_mac/tasks/utilities/system_env.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/utilities/system_env.yml
@@ -1,8 +1,0 @@
-- name: Verify system environment variable
-  shell: launchctl getenv {{ item.name }}
-  register: system_env
-  changed_when: no
-
-- name: Set system environment variable
-  shell: launchctl setenv {{ item.name }} "{{ item.value }}"
-  when:  item.value != system_env.stdout

--- a/bootstrap/roles/bootstrap_mac/tasks/utilities/user_aqua_env.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/utilities/user_aqua_env.yml
@@ -1,0 +1,21 @@
+- name: Get console user UID
+  shell: stat -f%u /dev/console
+  register: console_uid
+  changed_when: no
+
+- name: Warn when no GUI user is logged in
+  ansible.builtin.debug:
+    msg: "WARNING: No console user logged in; skipping user-scope launchctl setenv for {{ item.name }}."
+  when: console_uid.stdout == "0"
+
+- name: Verify user-scope environment variable
+  shell: launchctl asuser {{ console_uid.stdout }} launchctl getenv {{ item.name }}
+  register: aqua_env
+  changed_when: no
+  when: console_uid.stdout != "0"
+
+- name: Set user-scope environment variable
+  shell: launchctl asuser {{ console_uid.stdout }} launchctl setenv {{ item.name }} "{{ item.value }}"
+  when:
+    - console_uid.stdout != "0"
+    - (item.value | string) != (aqua_env.stdout | default(''))


### PR DESCRIPTION
Running under the bootstrap-mac system LaunchDaemon, `launchctl setenv` targeted the system-scope domain and was rejected by SIP (rc 150), wedging every run at the Ollama env setup. The GUI app reads env from the user Aqua session anyway, so the system-scope write is overly broad.

Detect the console user via `stat -f%u /dev/console` and prefix getenv/setenv with `launchctl asuser <uid>`. Skip gracefully when no GUI user is logged in rather than failing the play.