### PR TITLE
Mirror the application in /opt/purplejay to move outside App Management scope

### DIFF
--- a/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
@@ -5,9 +5,34 @@
   changed_when: "'Already up-to-date' not in brew_upgrade.stdout and 'Warning:' not in brew_upgrade.stderr"
   failed_when: brew_upgrade.rc != 0 and 'already installed' not in brew_upgrade.stderr | lower
 
-- name: Remove Gatekeeper quarantine from Ollama.app so the LaunchDaemon can exec headlessly
-  ansible.builtin.command: /usr/bin/xattr -dr com.apple.quarantine /Applications/Ollama.app
-  changed_when: false
+- name: Ensure parent directory for the headless Ollama bundle
+  ansible.builtin.file:
+    path: /opt/purplejay
+    state: directory
+    owner: root
+    group: wheel
+    mode: '0755'
+  become: yes
+
+# macOS App Management (Ventura+) blocks xattr modifications on anything under
+# /Applications/, even as root, so we cannot strip com.apple.quarantine there.
+# Mirror the bundle to /opt/purplejay/ (outside App Management's scope) and
+# exec from the copy. BSD rsync's -a does NOT include -X (xattrs), so the
+# quarantine attribute is dropped at copy time without a separate strip step.
+# Developer ID signature + notarization ticket live as regular files inside
+# the bundle and are preserved by the mirror.
+- name: Mirror Ollama.app out of /Applications to escape App Management
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/rsync
+      - -a
+      - --delete
+      - --itemize-changes
+      - /Applications/Ollama.app/
+      - /opt/purplejay/Ollama.app/
+  become: yes
+  register: ollama_mirror
+  changed_when: ollama_mirror.stdout | length > 0
 
 - name: Install Ollama LaunchDaemon plist
   ansible.builtin.template:
@@ -20,7 +45,7 @@
   register: ollama_plist
 
 - name: Reload Ollama LaunchDaemon
-  when: brew_upgrade.changed or ollama_plist.changed
+  when: brew_upgrade.changed or ollama_mirror.changed or ollama_plist.changed
   become: yes
   block:
 

--- a/bootstrap/roles/bootstrap_mac/templates/com.purplejay.ollama.plist.j2
+++ b/bootstrap/roles/bootstrap_mac/templates/com.purplejay.ollama.plist.j2
@@ -6,7 +6,7 @@
     <string>com.purplejay.ollama</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Ollama.app/Contents/Resources/ollama</string>
+        <string>/opt/purplejay/Ollama.app/Contents/Resources/ollama</string>
         <string>serve</string>
     </array>
     <key>UserName</key>


### PR DESCRIPTION
## Short explanation

Regrettably, #9 doesn't _quite_ work on all the Mac Studios. I'm actually a bit flummoxed about why it works (1) when running the bootstrap manually, and (2) seemingly, on some (all but one) of the Studios unattended. 

Nonetheless, I think this should work better as we drag MacOS kicking and screaming into being a server OS. This has been tested against prod-studio1 using

```
-t bootstrap
-t mac-crons
-p tasks/trigger-bootstrap-mac.yml
```

## Longer explanation

  The xattr -dr com.apple.quarantine /Applications/Ollama.app step from 9b724eb failed on prod-studio1 where the bundle actually has the attribute: "Operation not permitted" on every file, even as root. The cause is macOS App Management (TCC), which is scoped to root-owned bundles under /Applications/ and denies xattr modifications regardless of uid. It probably only "worked" on macs where the cask happened to have no quarantine xattr to strip (xattr silently returns 0 with nothing to do).

  This change mirrors the bundle to /opt/purplejay/Ollama.app/ via rsync -a --delete and points the LaunchDaemon at the copy. Apple's openrsync documents `-a` as `-Dgloprt`, with xattrs opt-in via `-E`, so `com.apple.quarantine` is dropped at copy time; thus, no strip step is needed after the copy. The destination is outside App Management's scope, so no TCC gate fires on future cask upgrades.                                                       

  Developer ID signature and notarization ticket live as regular files under Contents/_CodeSignature/ and Contents/CodeResources, which rsync copies byte-for-byte — `codesign --verify --deep --strict /opt/purplejay/Ollama.app` should continue to pass. The only thing we deliberately don't carry across is the quarantine xattr, which exists to drive an interactive first-run prompt we can't service headlessly.

  Further reading:                                                                                                         
  - https://manp.gs/mac/1/openrsync
  - https://www.l3harris.com/newsroom/editorial/2025/01/evolution-tcc-ventura — App Management scope                       
  - https://lapcatsoftware.com/articles/AppManagement.html — primary reverse-engineering            
  - https://eclecticlight.co/2025/11/08/explainer-permissions-privacy-and-tcc/ — broader TCC context 