### PR TITLE
Install Ollama from standalone darwin release

### DIFF
--- a/bootstrap/roles/bootstrap_mac/defaults/main.yml
+++ b/bootstrap/roles/bootstrap_mac/defaults/main.yml
@@ -96,10 +96,18 @@ ssh_tunnels: []
 ollama_install: no
 ollama_expose: no
 ollama_models: []
+ollama_keepalive_models: []
 ollama_absent_models: []
 ollama_host: "0.0.0.0"
 ollama_keep_alive: "24h"
 ollama_api_base: "http://127.0.0.1:11434"  # used for all API calls in the playbook
+# "latest" resolves to the newest GitHub release at run time. Override with a
+# specific version string (e.g. "0.21.2") to pin. When pinning, optionally set
+# ollama_darwin_tgz_sha256 to enforce byte-level reproducibility; codesign
+# --verify always runs regardless.
+ollama_version: "latest"
+ollama_darwin_tgz_sha256: ""
+ollama_install_dir: "/opt/purplejay/ollama"
 
 # OS Update
 os_upgrade: false

--- a/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
+++ b/bootstrap/roles/bootstrap_mac/tasks/ollama.yml
@@ -1,12 +1,99 @@
 ---
-- name: Upgrade Ollama via Homebrew Cask
-  ansible.builtin.command: "{{ homebrew_path }}/bin/brew upgrade --cask ollama-app"
-  register: brew_upgrade
-  changed_when: "'Already up-to-date' not in brew_upgrade.stdout and 'Warning:' not in brew_upgrade.stderr"
-  failed_when: brew_upgrade.rc != 0 and 'already installed' not in brew_upgrade.stderr | lower
+# Install Ollama from Ollama Inc.'s standalone darwin release (not the .app
+# cask). The cask wraps the same binary in an Ollama.app bundle, which macOS
+# Ventura+ App Management binds to TCC via com.apple.macl — blocking xattr
+# and timestamp writes even as root, regardless of install path (moving the
+# bundle does not shed the macl tag). The standalone tarball ships the same
+# Developer ID-signed binary (Team 3MU9H2V9Y9, identifier ai.ollama.ollama)
+# without a bundle, so TCC App Management does not engage.
+- name: Remove legacy Ollama.app cask if present
+  ansible.builtin.command: "{{ homebrew_path }}/bin/brew uninstall --cask ollama-app"
+  register: brew_uninstall_cask
+  changed_when: brew_uninstall_cask.rc == 0
+  failed_when:
+    - brew_uninstall_cask.rc != 0
+    - "'No such keg' not in brew_uninstall_cask.stderr"
+    - "'not installed' not in brew_uninstall_cask.stderr | lower"
 
-- name: Remove Gatekeeper quarantine from Ollama.app so the LaunchDaemon can exec headlessly
-  ansible.builtin.command: /usr/bin/xattr -dr com.apple.quarantine /Applications/Ollama.app
+# Use github.com's /releases/latest redirect instead of api.github.com to
+# avoid the 60/hour unauthenticated rate limit, which four studios behind one
+# NAT can exhaust quickly. The 302 Location header carries the resolved tag,
+# e.g. https://github.com/ollama/ollama/releases/tag/v0.21.2
+- name: Resolve latest Ollama release tag
+  ansible.builtin.uri:
+    url: https://github.com/ollama/ollama/releases/latest
+    method: HEAD
+    follow_redirects: none
+    status_code: 302
+  register: ollama_latest
+  when: ollama_version == "latest"
+
+- name: Determine effective Ollama version
+  ansible.builtin.set_fact:
+    ollama_resolved_version: >-
+      {{ (ollama_latest.location | regex_replace('.*/tag/v?', ''))
+         if ollama_version == "latest" else ollama_version }}
+
+- name: Download Ollama standalone darwin release
+  ansible.builtin.get_url:
+    url: "https://github.com/ollama/ollama/releases/download/v{{ ollama_resolved_version }}/ollama-darwin.tgz"
+    dest: "/tmp/ollama-darwin-{{ ollama_resolved_version }}.tgz"
+    checksum: "{{ ('sha256:' + ollama_darwin_tgz_sha256) if ollama_darwin_tgz_sha256 else omit }}"
+    mode: '0644'
+  register: ollama_download
+
+- name: Check whether Ollama binary is already installed
+  ansible.builtin.stat:
+    path: "{{ ollama_install_dir }}/ollama"
+  register: ollama_binary
+
+# Wipe any prior install tree so stale siblings (e.g. dylibs dropped in a
+# future release) don't linger alongside the new binary. Only fires when we
+# are about to extract; codesign integrity is still enforced downstream.
+- name: Remove stale Ollama install tree before extract
+  ansible.builtin.file:
+    path: "{{ ollama_install_dir }}"
+    state: absent
+  become: yes
+  when: ollama_download.changed or not ollama_binary.stat.exists
+
+- name: Ensure Ollama install directory exists
+  ansible.builtin.file:
+    path: "{{ ollama_install_dir }}"
+    state: directory
+    owner: root
+    group: wheel
+    mode: '0755'
+  become: yes
+
+# ansible.builtin.unarchive requires GNU tar for .tgz; macOS ships BSD tar,
+# which handles gzip fine but the module refuses by name. Invoke tar directly.
+# --no-same-owner makes extracted files owned by the running user (root under
+# become), yielding root:wheel ownership without a follow-up chown. Re-extract
+# on a fresh download (version bump) or whenever the binary is missing (e.g. a
+# prior run failed between download and extract).
+- name: Extract Ollama release into install directory
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/tar
+      - --no-same-owner
+      - -xzf
+      - "/tmp/ollama-darwin-{{ ollama_resolved_version }}.tgz"
+      - -C
+      - "{{ ollama_install_dir }}"
+  become: yes
+  when: ollama_download.changed or not ollama_binary.stat.exists
+  register: ollama_extract
+  changed_when: ollama_download.changed or not ollama_binary.stat.exists
+
+- name: Verify Ollama binary Developer ID signature
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/codesign
+      - --verify
+      - --verbose=2
+      - "{{ ollama_install_dir }}/ollama"
+  register: ollama_codesign
   changed_when: false
 
 - name: Install Ollama LaunchDaemon plist
@@ -19,8 +106,20 @@
   become: yes
   register: ollama_plist
 
+# Probe before deciding to reload so we self-heal when the daemon is down for
+# reasons unrelated to file changes (post-reboot launchd hiccup, manual
+# bootout, etc.). On the happy path this is sub-second and the reload block
+# is skipped, avoiding a needless service bounce.
+- name: Probe Ollama API to detect a stopped daemon
+  ansible.builtin.uri:
+    url: "{{ ollama_api_base }}/api/version"
+    timeout: 2
+  register: ollama_probe
+  failed_when: false
+  changed_when: false
+
 - name: Reload Ollama LaunchDaemon
-  when: brew_upgrade.changed or ollama_plist.changed
+  when: ollama_extract.changed or ollama_plist.changed or ollama_probe.status != 200
   become: yes
   block:
 

--- a/bootstrap/roles/bootstrap_mac/templates/com.purplejay.ollama.plist.j2
+++ b/bootstrap/roles/bootstrap_mac/templates/com.purplejay.ollama.plist.j2
@@ -6,7 +6,7 @@
     <string>com.purplejay.ollama</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Ollama.app/Contents/Resources/ollama</string>
+        <string>{{ ollama_install_dir }}/ollama</string>
         <string>serve</string>
     </array>
     <key>UserName</key>


### PR DESCRIPTION
## Short version

In this case it's likely best to sidestep Homebrew, if we want to stick with built-by-vendor supply chain (which you were doing before with the cask, and I think make sense). I believe if we were to switch to the Homebrew formula, you would not get Ollama dev signed binaries, instead ad hoc signed and built by Homebrew CI.

But the problem with the cask is that it makes an .app, and that triggers all the MacOS babysitting. Downloading the release directly from Ollama GitHub gives us a signed binary, but not an "app," so it works well as a service.

## Long version

Switch from the Homebrew ollama-app cask to the standalone ollama-darwin.tgz release from github.com/ollama/ollama. Both artifacts ship the same Developer ID-signed binary (Team 3MU9H2V9Y9, identifier ai.ollama.ollama), but the cask wraps it in an Ollama.app bundle that macOS Ventura+ binds to TCC App Management via the com.apple.macl extended attribute — blocking xattr and timestamp writes even as root, persisting across path moves, and preventing the earlier `xattr -dr com.apple.quarantine` approach from running headless. The standalone tarball has no bundle, so App Management does not engage.

ollama_version defaults to "latest" and resolves against the GitHub releases API at run time; override to a version string (e.g. "0.21.2") to pin. ollama_darwin_tgz_sha256 is optional and enforced only when set. codesign --verify runs unconditionally and catches tampering via Ollama's Developer ID signature regardless of whether a sha256 is pinned.

The install tree at {{ ollama_install_dir }} is wiped before each extract so stale siblings (e.g. a dylib dropped in a future release) don't coexist with the new install. The legacy Ollama.app cask is uninstalled idempotently on first run.